### PR TITLE
chore: pin `ahash` to `0.8.6`

### DIFF
--- a/bounded-static/Cargo.toml
+++ b/bounded-static/Cargo.toml
@@ -31,7 +31,7 @@ bounded-static-derive = { version = "0.7.0", path = "../bounded-static-derive", 
 smol_str = { version = "0.2.0", optional = true, default_features = false }
 smallvec = { version = "1.11.1", optional = true, default_features = false }
 smartstring = { version = "1.0.1", optional = true, default_features = false }
-ahash = { version = "0.8.6", optional = true, default-features = false }
+ahash = { version = "=0.8.7", optional = true, default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Bump and pin `aHash` to `0.8.7` as `0.8.8` bumps the MSRV to 1.72.

See https://github.com/tkaitchuck/aHash/issues/179