### PR TITLE
chore: workaround for redundant import checking

### DIFF
--- a/bounded-static/src/lib.rs
+++ b/bounded-static/src/lib.rs
@@ -165,7 +165,10 @@
 #![warn(clippy::all, clippy::pedantic, clippy::nursery, rust_2018_idioms)]
 #![allow(clippy::missing_const_for_fn)]
 #![forbid(unsafe_code)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "alloc")]
 extern crate alloc;


### PR DESCRIPTION
see https://github.com/rust-lang/rust/issues/121708