### PR TITLE
chore: update deny.toml file to replace Unicode-DFS-2016 with Unicode-3.0

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,6 @@
 [licenses]
 version = 2
-allow = [ "Apache-2.0", "MPL-2.0", "Unicode-DFS-2016" ]
+allow = [ "Apache-2.0", "MPL-2.0", "Unicode-3.0" ]
 confidence-threshold = 0.8
 exceptions = []
 


### PR DESCRIPTION
Update the `deny.toml` file to replace "Unicode-DFS-2016" with "Unicode-3.0".

* Replace "Unicode-DFS-2016" with "Unicode-3.0" in the `allow` section under `[licenses]`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fujiapple852/bounded-static/pull/94?shareId=ca0ea846-942d-4608-adfc-87ee102a8111).